### PR TITLE
chore: add commitlint config bugs metadata

### DIFF
--- a/@pob/commitlint-config/package.json
+++ b/@pob/commitlint-config/package.json
@@ -6,6 +6,9 @@
     "commitlint"
   ],
   "homepage": "https://github.com/christophehurpeau/pob",
+  "bugs": {
+    "url": "https://github.com/christophehurpeau/pob/issues"
+  },
   "license": "ISC",
   "author": "Christophe Hurpeau <christophe@hurpeau.com> (https://christophe.hurpeau.com)",
   "repository": {


### PR DESCRIPTION
Summary:
- Add `bugs.url` metadata to the `@pob/commitlint-config` package manifest.
- Point the package's npm issue link to the repository issue tracker, matching the support metadata already used by the main `pob` package.
- Leave runtime code, exports, dependencies, generated files, and version fields unchanged.

Validation:
- `node -e "const pkg=require('./@pob/commitlint-config/package.json'); if(pkg.name !== '@pob/commitlint-config') throw new Error('wrong package'); if(pkg.bugs?.url !== 'https://github.com/christophehurpeau/pob/issues') throw new Error('missing bugs.url'); console.log(JSON.stringify({name:pkg.name, bugs:pkg.bugs}, null, 2));"`
- `npm pack --dry-run --ignore-scripts --json` from `@pob/commitlint-config`
- `git diff --check` (passed with only a Windows line-ending warning)