### PR TITLE
chore(commitlint-config): add bugs metadata

### DIFF
--- a/@pob/commitlint-config/package.json
+++ b/@pob/commitlint-config/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/christophehurpeau/pob.git",
     "directory": "@pob/commitlint-config"
   },
+  "bugs": {
+    "url": "https://github.com/christophehurpeau/pob/issues"
+  },
   "files": [
     "lib"
   ],


### PR DESCRIPTION
## Summary
- add the missing npm `bugs.url` metadata for `@pob/commitlint-config`
- point issue reporting to the repository issue tracker
- leave runtime code, dependencies, generated files, version fields, and exports unchanged

## Verification
- `node - <<'NODE' ...` package metadata assertion for `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` in `@pob/commitlint-config`
- `git diff --check`